### PR TITLE
Blog Fixed to use the default SCA Template

### DIFF
--- a/templates/views/blog.html
+++ b/templates/views/blog.html
@@ -1,4 +1,4 @@
-{% extends "layouts/default.html" %}
+{% extends "layouts/default.html" %} 
 
 {% macro blogPost(post) %}
 <div class="post" data-ks-editable="editable(user, { list: " Post ", id: post.id })">

--- a/templates/views/layouts/default.html
+++ b/templates/views/layouts/default.html
@@ -13,8 +13,8 @@
 		{# Customise the stylesheet for your site by editing /public/styles/site.sass #}
 		<link href="/styles/site.css" rel="stylesheet">
 		<!-- CUSTOM STYLES -->
-		<link rel="stylesheet" type="text/css" href="styles/main.css">
-		<link rel="stylesheet" type="text/css" href="styles/index.css">
+		<link rel="stylesheet" type="text/css" href="/styles/main.css">
+		<link rel="stylesheet" type="text/css" href="/styles/index.css">
 		<!-- WEBFONT -->
 		<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway">
 
@@ -54,7 +54,7 @@
 							<span class="icon-bar"></span>
 							<span class="icon-bar"></span>
 						</button>
-						<a class="navbar-brand" href="/"><img src="images/shecodelogo.svg" class="__shecodelogo"></a>
+						<a class="navbar-brand" href="/"><img src="/images/shecodelogo.svg" class="__shecodelogo"></a>
 					</div>
 					<!-- TOGGLING LINKS -->
 					<div class="collapse navbar-collapse navbar-ex1-collapse __shecodenavcol">


### PR DESCRIPTION
The individual post pages (that are plain texts) have been fixed. Now they use the default SCA Website Template. I also created a post on my end to test it works. Attached is a screenshot of what it looks like now.
![Screenshot from 2019-09-27 11-08-23](https://user-images.githubusercontent.com/31415689/65762011-ec82c000-e117-11e9-9400-efc3dade39c8.png)

